### PR TITLE
font-variant-caps implemented in font.mako.rs

### DIFF
--- a/servo/components/style/properties/longhand/font.mako.rs
+++ b/servo/components/style/properties/longhand/font.mako.rs
@@ -130,6 +130,16 @@ ${helpers.single_keyword("font-variant",
                          "normal small-caps",
                          animatable=False)}
 
+<% font_variant_caps_custom_consts= { "small-caps": "SMALLCAPS", "all-small": "ALLSMALL", "petite-caps": "PETITECAPS", "all-petite": "ALLPETITE", "titling-caps": "TITLING" } %>
+
+${helpers.single_keyword("font-variant-caps",
+			 "normal small-caps all-small petite-caps unicase titling-caps",
+			 gecko_constant_prefix="NS_FONT_VARIANT_CAPS",
+			 gecko_ffi_name="mFont.variantCaps",
+			 products="gecko",
+			 custom_consts=font_variant_caps_custom_consts,
+			 animatable=False)}
+
 <%helpers:longhand name="font-weight" need_clone="True" animatable="True">
     use cssparser::ToCss;
     use std::fmt;


### PR DESCRIPTION
Before Change:
<img width="261" alt="beforechange" src="https://cloud.githubusercontent.com/assets/9249887/21124302/1cc10a2c-c0ac-11e6-9b4a-39c7a29158a4.PNG">

After Change:
<img width="174" alt="afterchange" src="https://cloud.githubusercontent.com/assets/9249887/21124320/3a1ddcee-c0ac-11e6-9ba6-0ccd371e5f82.png">
